### PR TITLE
ci: re-enable server and client tests in pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,14 +24,12 @@ jobs:
           node-version: 20
           cache: npm
           cache-dependency-path: clinic-system/client/package-lock.json
-      # Server tests temporarily disabled due to failing /api/clinics endpoint (returns 500)
-      # Will be re-enabled once backend issue is resolved
-      #- name: Install server dependencies
-      #  working-directory: clinic-system/server
-      #  run: npm ci
-      #- name: Run server tests
-      #  working-directory: clinic-system/server
-      #  run: npm test
+      - name: Install server dependencies
+        working-directory: clinic-system/server
+        run: npm ci
+      - name: Run server tests
+        working-directory: clinic-system/server
+        run: npm test
       - name: Install client dependencies
         working-directory: clinic-system/client
         run: npm ci


### PR DESCRIPTION
Re-enabled CI pipeline to run both server and client tests before build.

Ensures automated testing is executed for both backend and frontend in CI.
