### PR TITLE
fix: add Supabase env vars to CI server tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,14 +24,15 @@ jobs:
           node-version: 20
           cache: npm
           cache-dependency-path: clinic-system/client/package-lock.json
-      # Server tests temporarily disabled due to failing /api/clinics endpoint (returns 500)
-      # Will be re-enabled once backend issue is resolved
-      #- name: Install server dependencies
-      #  working-directory: clinic-system/server
-      #  run: npm ci
-      #- name: Run server tests
-      #  working-directory: clinic-system/server
-      #  run: npm test
+      - name: Install server dependencies
+        working-directory: clinic-system/server
+        run: npm ci
+      - name: Run server tests
+        working-directory: clinic-system/server
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+        run: npm test
       - name: Install client dependencies
         working-directory: clinic-system/client
         run: npm ci


### PR DESCRIPTION
- updated GitHub Actions workflow to pass Supabase env vars to server tests
- ensures CI has the required environment variables for Jest/server test execution
- server tests were passing locally via .env
- GitHub Actions failed because SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY were not available in CI