### PR TITLE
feat: add queue validation helpers and unit tests

### DIFF
--- a/clinic-system/server/src/queueValidation.js
+++ b/clinic-system/server/src/queueValidation.js
@@ -1,0 +1,43 @@
+// Checks whether the patient actually confirmed the queue join action.
+// This helps us make sure a join cannot happen accidentally.
+function isJoinConfirmed(confirmed) {
+  return confirmed === true
+}
+
+// Checks whether the patient already has an active queue entry.
+// For now, any queue entry that is not Complete counts as still active.
+function canJoinQueue(patientId, activeQueues) {
+  return !activeQueues.some(
+    (entry) =>
+      entry.patient_id === patientId &&
+      entry.status !== 'Complete'
+  )
+}
+
+// Main validation helper for queue joining.
+// A join is only valid if the patient confirmed the action
+// and does not already have an active queue entry.
+function validateQueueJoin(patientId, activeQueues, confirmed) {
+  if (!isJoinConfirmed(confirmed)) return false
+  if (!canJoinQueue(patientId, activeQueues)) return false
+  return true
+}
+
+// Checks whether a queue status change follows the expected lifecycle.
+// This keeps staff from making invalid jumps between states.
+function isValidStatusTransition(currentStatus, nextStatus) {
+  const validTransitions = {
+    Waiting: ['In Consultation'],
+    'In Consultation': ['Complete'],
+    Complete: [],
+  }
+
+  return validTransitions[currentStatus]?.includes(nextStatus) || false
+}
+
+module.exports = {
+  isJoinConfirmed,
+  canJoinQueue,
+  validateQueueJoin,
+  isValidStatusTransition,
+}

--- a/clinic-system/server/tests/queueValidation.test.js
+++ b/clinic-system/server/tests/queueValidation.test.js
@@ -1,0 +1,70 @@
+const {
+  isJoinConfirmed,
+  canJoinQueue,
+  validateQueueJoin,
+  isValidStatusTransition,
+} = require('../src/queueValidation')
+
+describe('Queue join validation helpers', () => {
+  test('returns true when the join action is confirmed', () => {
+    expect(isJoinConfirmed(true)).toBe(true)
+  })
+
+  test('returns false when the join action is not confirmed', () => {
+    expect(isJoinConfirmed(false)).toBe(false)
+  })
+
+  test('prevents a patient from joining if they already have an active queue entry', () => {
+    const activeQueues = [
+      { patient_id: 'patient-1', status: 'Waiting' },
+    ]
+
+    expect(canJoinQueue('patient-1', activeQueues)).toBe(false)
+  })
+
+  test('allows a patient to join if they do not already have an active queue entry', () => {
+    const activeQueues = [
+      { patient_id: 'patient-2', status: 'Waiting' },
+    ]
+
+    expect(canJoinQueue('patient-1', activeQueues)).toBe(true)
+  })
+
+  test('rejects queue join if the action was not confirmed', () => {
+    expect(validateQueueJoin('patient-1', [], false)).toBe(false)
+  })
+
+  test('rejects queue join if the patient is already in an active queue', () => {
+    const activeQueues = [
+      { patient_id: 'patient-1', status: 'Waiting' },
+    ]
+
+    expect(validateQueueJoin('patient-1', activeQueues, true)).toBe(false)
+  })
+
+  test('allows queue join when the action is confirmed and there is no active queue entry', () => {
+    expect(validateQueueJoin('patient-1', [], true)).toBe(true)
+  })
+})
+
+describe('Queue status transition validation', () => {
+  test('allows Waiting to move to In Consultation', () => {
+    expect(isValidStatusTransition('Waiting', 'In Consultation')).toBe(true)
+  })
+
+  test('allows In Consultation to move to Complete', () => {
+    expect(isValidStatusTransition('In Consultation', 'Complete')).toBe(true)
+  })
+
+  test('rejects Complete moving back to Waiting', () => {
+    expect(isValidStatusTransition('Complete', 'Waiting')).toBe(false)
+  })
+
+  test('rejects invalid direct transition from Waiting to Complete', () => {
+    expect(isValidStatusTransition('Waiting', 'Complete')).toBe(false)
+  })
+
+  test('rejects unknown current statuses', () => {
+    expect(isValidStatusTransition('Unknown', 'Waiting')).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
This PR introduces reusable validation logic for queue operations, along with unit tests to ensure correct behaviour.

## What was implemented
- Added `queueValidation.js` helper module:
  - validation for queue join confirmation
  - prevention of duplicate/active queue entries
  - validation of queue status transitions

- Added unit tests for:
  - queue join validation rules
  - status transition logic
  - edge cases (invalid transitions, duplicate joins, unconfirmed joins)

## Why this is needed
This establishes the validation layer for the queue system, ensuring that:
- patients cannot join a queue accidentally or multiple times
- staff cannot perform invalid status transitions

These helpers are designed to be reused across the backend once queue write/update endpoints are implemented.

## Notes
- This PR focuses on validation logic in isolation (unit-tested)
- Integration into API routes will follow once queue join and status update endpoints are available

## How to test
From the `server` directory:

```bash
npm test -- queueValidation.test.js