### PR TITLE
fix: restore correct OAuth redirect flow

### DIFF
--- a/clinic-system/client/src/context/AuthContext.jsx
+++ b/clinic-system/client/src/context/AuthContext.jsx
@@ -124,7 +124,7 @@ async function loginWithGoogle() {
     const { error } = await supabase.auth.signInWithOAuth({
       provider: 'google',
       options: {
-        redirectTo: 'https://ubuntu-health-geb6dbegejfmenc7.southafricanorth-01.azurewebsites.net',
+        redirectTo: `${window.location.origin}/login`,
       },
     })
 


### PR DESCRIPTION
## Fix OAuth Login Issue

This PR restores the original OAuth redirect behaviour after login failures were introduced when deploying to Azure.

### What was changed
- Reverted `redirectTo` from a hardcoded Azure URL:
  ```js
  https://ubuntu-health-geb6dbegejfmenc7.southafricanorth-01.azurewebsites.net
- Restore Dynamic redirect
  ```js
      ${window.location.origin}/login