### PR TITLE
fix: prevent duplicate active queue entries

### DIFF
--- a/clinic-system/schema.sql
+++ b/clinic-system/schema.sql
@@ -83,7 +83,10 @@ create table queue_entries (
   called_at timestamp,      -- set when staff calls the patient
   completed_at timestamp    -- set when consultation is marked complete
 );
-
+-- Prevent multiple active queue entries per patient
+create unique index unique_active_queue_per_patient
+on queue_entries (patient_id)
+where status <> 'Complete';
 
 -- ─── FUTURE SPRINT TABLES ─────────────────────────────────────────────────────
 

--- a/clinic-system/server/src/app.js
+++ b/clinic-system/server/src/app.js
@@ -528,8 +528,15 @@ app.post('/api/queue/:clinicId/join', async (req, res) => {
       })
       .select()
       .single()
-
-    if (insertError) throw insertError
+    if (insertError) {
+      if (insertError.code === '23505') {
+        return res.status(409).json({
+        error: 'Patient already has an active queue entry'
+      })
+    }
+      throw insertError
+  }
+    //if (insertError) throw insertError
 
     res.status(201).json({ entry: newEntry })
   } catch (err) {


### PR DESCRIPTION
What changed:
- Added a database-level unique index to prevent multiple active queue entries per patient
- Updated backend handling to return a 409 conflict for duplicate join attempts
- Updated schema.sql to reflect the database constraint

Why:
This fixes a race condition where simultaneous queue join requests could create duplicate active entries for the same patient.
