### PR TITLE
feat: send appointment confirmation email after successful booking

### DIFF
--- a/clinic-system/server/package-lock.json
+++ b/clinic-system/server/package-lock.json
@@ -12,7 +12,8 @@
         "@supabase/supabase-js": "^2.101.1",
         "cors": "^2.8.6",
         "dotenv": "^17.4.0",
-        "express": "^5.2.1"
+        "express": "^5.2.1",
+        "resend": "^6.12.2"
       },
       "devDependencies": {
         "jest": "^30.3.0",
@@ -50,6 +51,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1071,6 +1073,12 @@
         "@sinonjs/commons": "^3.0.1"
       }
     },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
+    },
     "node_modules/@supabase/auth-js": {
       "version": "2.101.1",
       "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.101.1.tgz",
@@ -1840,6 +1848,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -2609,6 +2618,12 @@
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
     },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
@@ -4398,6 +4413,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/postal-mime": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/postal-mime/-/postal-mime-2.7.4.tgz",
+      "integrity": "sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==",
+      "license": "MIT-0"
+    },
     "node_modules/pretty-format": {
       "version": "30.3.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.3.0.tgz",
@@ -4510,6 +4531,27 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resend": {
+      "version": "6.12.2",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-6.12.2.tgz",
+      "integrity": "sha512-xwgmU4b0OqoabJsIoK/x0Whk0Fcs3bpbK4i/DEWPiE5hYJHyHl0TbB6QbI3gIr+bLdLUJ1GYm/fe41aVFuHXgw==",
+      "license": "MIT",
+      "dependencies": {
+        "postal-mime": "2.7.4",
+        "svix": "1.90.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@react-email/render": "*"
+      },
+      "peerDependenciesMeta": {
+        "@react-email/render": {
+          "optional": true
+        }
       }
     },
     "node_modules/resolve-cwd": {
@@ -4777,6 +4819,16 @@
         "node": ">=10"
       }
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -5009,6 +5061,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/svix": {
+      "version": "1.90.0",
+      "resolved": "https://registry.npmjs.org/svix/-/svix-1.90.0.tgz",
+      "integrity": "sha512-ljkZuyy2+IBEoESkIpn8sLM+sxJHQcPxlZFxU+nVDhltNfUMisMBzWX/UR8SjEnzoI28ZjCzMbmYAPwSTucoMw==",
+      "license": "MIT",
+      "dependencies": {
+        "standardwebhooks": "1.0.0",
+        "uuid": "^10.0.0"
+      }
+    },
     "node_modules/synckit": {
       "version": "0.11.12",
       "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.12.tgz",
@@ -5224,6 +5286,20 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/v8-to-istanbul": {

--- a/clinic-system/server/package.json
+++ b/clinic-system/server/package.json
@@ -20,7 +20,8 @@
     "@supabase/supabase-js": "^2.101.1",
     "cors": "^2.8.6",
     "dotenv": "^17.4.0",
-    "express": "^5.2.1"
+    "express": "^5.2.1",
+    "resend": "^6.12.2"
   },
   "devDependencies": {
     "jest": "^30.3.0",

--- a/clinic-system/server/src/app.js
+++ b/clinic-system/server/src/app.js
@@ -3,7 +3,7 @@ const cors = require('cors')
 const path = require('path')
 const { createClient } = require('@supabase/supabase-js')
 require('dotenv').config()
-
+const { sendAppointmentConfirmationEmail } = require('./emailService')
 const app = express()
 const DEFAULT_ESTIMATED_WAIT_APPOINTMENT_DURATION = 15
 const ESTIMATED_WAIT_FALLBACK_MESSAGE = 'Estimated wait time may be inaccurate'
@@ -2523,10 +2523,47 @@ const slot_datetime = selectedSlotValidation.slotDateTime
 
     if (error) throw error
 
-    return res.status(201).json({
-      message: 'Appointment booked successfully',
-      appointment: data,
-    })
+    // US-28-1/2/3/4: Send confirmation email after successful booking
+const patientEmail = data.patient_email || null
+
+// Fetch patient email and name if not on appointment record
+let emailAddress = null
+let patientName = null
+
+const { data: patientUser } = await supabase
+  .from('users')
+  .select('email, full_name')
+  .eq('id', patient_id)
+  .maybeSingle()
+
+if (patientUser) {
+  emailAddress = patientUser.email
+  patientName = patientUser.full_name
+} else {
+  const { data: patientRecord } = await supabase
+    .from('patients')
+    .select('email, full_name')
+    .eq('id', patient_id)
+    .maybeSingle()
+
+  emailAddress = patientRecord?.email || null
+  patientName = patientRecord?.full_name || null
+}
+
+// Fire and forget — email failure must not affect booking response
+sendAppointmentConfirmationEmail({
+  to: emailAddress,
+  patientName,
+  clinicName: clinic.name,
+  date,
+  time: normalizedTime || time,
+}).catch(err => console.error('Email send failed silently:', err))
+
+return res.status(201).json({
+  message: 'Appointment booked successfully',
+  appointment: data,
+})
+
   } catch (err) {
     console.error(err)
 

--- a/clinic-system/server/src/emailService.js
+++ b/clinic-system/server/src/emailService.js
@@ -1,6 +1,12 @@
 const { Resend } = require('resend')
 
-const resend = new Resend(process.env.RESEND_API_KEY)
+function getResendClient() {
+  const resend = getResendClient()
+if (!resend) {
+  console.warn('sendAppointmentConfirmationEmail: RESEND_API_KEY not set, skipping')
+  return { sent: false, reason: 'no_api_key' }
+}
+}
 
 function buildAppointmentConfirmationEmail({ patientName, clinicName, date, time }) {
   const displayName = patientName || 'Patient'

--- a/clinic-system/server/src/emailService.js
+++ b/clinic-system/server/src/emailService.js
@@ -1,0 +1,72 @@
+const { Resend } = require('resend')
+
+const resend = new Resend(process.env.RESEND_API_KEY)
+
+function buildAppointmentConfirmationEmail({ patientName, clinicName, date, time }) {
+  const displayName = patientName || 'Patient'
+  const displayDate = date || 'Unknown date'
+  const displayTime = time || 'Unknown time'
+  const displayClinic = clinicName || 'the clinic'
+
+  const subject = `Appointment Confirmation — ${displayClinic}`
+
+  const text = `
+Hi ${displayName},
+
+Your appointment has been confirmed.
+
+Clinic:  ${displayClinic}
+Date:    ${displayDate}
+Time:    ${displayTime}
+
+Please arrive a few minutes early. If you need to cancel or reschedule, please contact the clinic directly.
+
+Ubuntu Health
+  `.trim()
+
+  return { subject, text }
+}
+
+async function sendAppointmentConfirmationEmail({ to, patientName, clinicName, date, time }) {
+  if (!to) {
+    console.warn('sendAppointmentConfirmationEmail: no recipient email, skipping')
+    return { sent: false, reason: 'no_email' }
+  }
+
+  if (!process.env.RESEND_API_KEY) {
+    console.warn('sendAppointmentConfirmationEmail: RESEND_API_KEY not set, skipping')
+    return { sent: false, reason: 'no_api_key' }
+  }
+
+  const { subject, text } = buildAppointmentConfirmationEmail({
+    patientName,
+    clinicName,
+    date,
+    time,
+  })
+
+  try {
+    const { data, error } = await resend.emails.send({
+      from: 'Ubuntu Health <no-reply@ubuntuhealth.co.za>',
+      to,
+      subject,
+      text,
+    })
+
+    if (error) {
+      console.error('Failed to send confirmation email:', error)
+      return { sent: false, reason: 'resend_error', error }
+    }
+
+    console.log('Confirmation email sent:', data?.id)
+    return { sent: true, id: data?.id }
+  } catch (err) {
+    console.error('Failed to send confirmation email:', err)
+    return { sent: false, reason: 'exception', error: err }
+  }
+}
+
+module.exports = {
+  buildAppointmentConfirmationEmail,
+  sendAppointmentConfirmationEmail,
+}


### PR DESCRIPTION
- Add emailService.js with buildAppointmentConfirmationEmail and sendAppointmentConfirmationEmail
- Trigger email after successful booking in POST /api/appointments
- Email failures are non-fatal and do not affect booking response
- Closes #633, #634, #635, #636