### PR TITLE
feat: send cancellation and reschedule confirmation emails

### DIFF
--- a/clinic-system/server/src/app.js
+++ b/clinic-system/server/src/app.js
@@ -3,7 +3,11 @@ const cors = require('cors')
 const path = require('path')
 const { createClient } = require('@supabase/supabase-js')
 require('dotenv').config()
-const { sendAppointmentConfirmationEmail } = require('./emailService')
+const {
+  sendAppointmentConfirmationEmail,
+  sendAppointmentCancellationEmail,
+  sendAppointmentRescheduleEmail,
+} = require('./emailService')
 const app = express()
 const DEFAULT_ESTIMATED_WAIT_APPOINTMENT_DURATION = 15
 const ESTIMATED_WAIT_FALLBACK_MESSAGE = 'Estimated wait time may be inaccurate'
@@ -3024,14 +3028,61 @@ if (!slotCapacityValidation.valid) {
       })
     }
 
+    // Fetch patient email and name for reschedule email
+    let rescheduleEmailAddress = null
+    let reschedulePatientName = null
+
+    const { data: reschedulePatientUser } = await supabase
+      .from('users')
+      .select('email, full_name')
+      .eq('id', appointment.patient_id)
+      .maybeSingle()
+
+    if (reschedulePatientUser) {
+      rescheduleEmailAddress = reschedulePatientUser.email
+      reschedulePatientName = reschedulePatientUser.full_name
+    } else {
+      const { data: reschedulePatientRecord } = await supabase
+        .from('patients')
+        .select('email, full_name')
+        .eq('id', appointment.patient_id)
+        .maybeSingle()
+
+      rescheduleEmailAddress = reschedulePatientRecord?.email || null
+      reschedulePatientName = reschedulePatientRecord?.full_name || null
+    }
+
+    // Fetch old slot datetime
+    let oldSlotDatetime = null
+    if (oldSlotId) {
+      const { data: oldSlotRecord } = await supabase
+        .from('slots')
+        .select('slot_datetime')
+        .eq('id', oldSlotId)
+        .maybeSingle()
+
+      oldSlotDatetime = oldSlotRecord?.slot_datetime || null
+    }
+
+    // Fire and forget — email failure must not affect reschedule response
+    sendAppointmentRescheduleEmail({
+      to: rescheduleEmailAddress,
+      patientName: reschedulePatientName,
+      clinicName: clinic.name,
+      newDate: date,
+      newTime: requestedTime,
+      oldDate: oldSlotDatetime ? oldSlotDatetime.slice(0, 10) : null,
+      oldTime: oldSlotDatetime ? getTimeFromAppointmentDatetime(oldSlotDatetime) : null,
+    }).catch(err => console.error('Reschedule email send failed silently:', err))
+
     return res.json(
-  buildRescheduleResponse({
-    appointment,
-    updatedAppointment: data,
-    oldSlotId,
-    newSlot,
-  })
-)
+      buildRescheduleResponse({
+        appointment,
+        updatedAppointment: data,
+        oldSlotId,
+        newSlot,
+      })
+    )
   } catch (err) {
     console.error('Failed to reschedule appointment:', err)
     return res.status(500).json({ error: 'Failed to reschedule appointment' })
@@ -3085,6 +3136,65 @@ app.patch('/api/appointments/:id/cancel', async (req, res) => {
       slotId: appointment.slot_id,
       capacity: staffCount,
     })
+
+    // Fetch patient email and name for cancellation email
+    let cancelEmailAddress = null
+    let cancelPatientName = null
+
+    const { data: cancelPatientUser } = await supabase
+      .from('users')
+      .select('email, full_name')
+      .eq('id', data.patient_id)
+      .maybeSingle()
+
+    if (cancelPatientUser) {
+      cancelEmailAddress = cancelPatientUser.email
+      cancelPatientName = cancelPatientUser.full_name
+    } else {
+      const { data: cancelPatientRecord } = await supabase
+        .from('patients')
+        .select('email, full_name')
+        .eq('id', data.patient_id)
+        .maybeSingle()
+
+      cancelEmailAddress = cancelPatientRecord?.email || null
+      cancelPatientName = cancelPatientRecord?.full_name || null
+    }
+
+    // Fetch slot datetime for email content
+    let cancelSlotDatetime = null
+    if (data.slot_id) {
+      const { data: cancelSlot } = await supabase
+        .from('slots')
+        .select('slot_datetime')
+        .eq('id', data.slot_id)
+        .maybeSingle()
+
+      cancelSlotDatetime = cancelSlot?.slot_datetime || null
+    }
+
+    const cancelDate = cancelSlotDatetime
+      ? cancelSlotDatetime.slice(0, 10)
+      : null
+    const cancelTime = cancelSlotDatetime
+      ? getTimeFromAppointmentDatetime(cancelSlotDatetime)
+      : null
+
+    // Fetch clinic name
+    const { data: cancelClinic } = await supabase
+      .from('clinics')
+      .select('name')
+      .eq('id', data.clinic_id)
+      .maybeSingle()
+
+    // Fire and forget — email failure must not affect cancellation response
+    sendAppointmentCancellationEmail({
+      to: cancelEmailAddress,
+      patientName: cancelPatientName,
+      clinicName: cancelClinic?.name || null,
+      date: cancelDate,
+      time: cancelTime,
+    }).catch(err => console.error('Cancellation email send failed silently:', err))
 
     return res.json(
       buildCancelResponse({

--- a/clinic-system/server/src/app.js
+++ b/clinic-system/server/src/app.js
@@ -3028,6 +3028,8 @@ if (!slotCapacityValidation.valid) {
       })
     }
 
+    try {
+
     // Fetch patient email and name for reschedule email
     let rescheduleEmailAddress = null
     let reschedulePatientName = null
@@ -3074,6 +3076,10 @@ if (!slotCapacityValidation.valid) {
       oldDate: oldSlotDatetime ? oldSlotDatetime.slice(0, 10) : null,
       oldTime: oldSlotDatetime ? getTimeFromAppointmentDatetime(oldSlotDatetime) : null,
     }).catch(err => console.error('Reschedule email send failed silently:', err))
+
+    } catch (emailErr) {
+      console.error('Failed to prepare reschedule email, skipping:', emailErr)
+    }
 
     return res.json(
       buildRescheduleResponse({
@@ -3137,6 +3143,10 @@ app.patch('/api/appointments/:id/cancel', async (req, res) => {
       capacity: staffCount,
     })
 
+    try{
+
+    
+
     // Fetch patient email and name for cancellation email
     let cancelEmailAddress = null
     let cancelPatientName = null
@@ -3189,13 +3199,15 @@ app.patch('/api/appointments/:id/cancel', async (req, res) => {
 
     // Fire and forget — email failure must not affect cancellation response
     sendAppointmentCancellationEmail({
-      to: cancelEmailAddress,
-      patientName: cancelPatientName,
-      clinicName: cancelClinic?.name || null,
-      date: cancelDate,
-      time: cancelTime,
-    }).catch(err => console.error('Cancellation email send failed silently:', err))
-
+    to: cancelEmailAddress,
+    patientName: cancelPatientName,
+    clinicName: cancelClinic?.name || null,
+    date: cancelDate,
+    time: cancelTime,
+  }).catch(err => console.error('Cancellation email send failed silently:', err))
+} catch (emailErr) {
+  console.error('Failed to prepare cancellation email, skipping:', emailErr)
+}
     return res.json(
       buildCancelResponse({
         appointment: data,

--- a/clinic-system/server/src/emailService.js
+++ b/clinic-system/server/src/emailService.js
@@ -72,7 +72,136 @@ async function sendAppointmentConfirmationEmail({ to, patientName, clinicName, d
   }
 }
 
+function buildAppointmentCancellationEmail({ patientName, clinicName, date, time }) {
+  const displayName = patientName || 'Patient'
+  const displayDate = date || 'Unknown date'
+  const displayTime = time || 'Unknown time'
+  const displayClinic = clinicName || 'the clinic'
+
+  const subject = `Appointment Cancelled — ${displayClinic}`
+
+  const text = `
+Hi ${displayName},
+
+Your appointment has been cancelled.
+
+Clinic:  ${displayClinic}
+Date:    ${displayDate}
+Time:    ${displayTime}
+
+If you did not request this cancellation or would like to rebook, please contact the clinic directly.
+
+Ubuntu Health
+  `.trim()
+
+  return { subject, text }
+}
+
+async function sendAppointmentCancellationEmail({ to, patientName, clinicName, date, time }) {
+  if (!to) {
+    console.warn('sendAppointmentCancellationEmail: no recipient email, skipping')
+    return { sent: false, reason: 'no_email' }
+  }
+
+  const transporter = getTransporter()
+  if (!transporter) {
+    console.warn('sendAppointmentCancellationEmail: GMAIL_USER or GMAIL_APP_PASSWORD not set, skipping')
+    return { sent: false, reason: 'no_credentials' }
+  }
+
+  const { subject, text } = buildAppointmentCancellationEmail({
+    patientName,
+    clinicName,
+    date,
+    time,
+  })
+
+  try {
+    const info = await transporter.sendMail({
+      from: `Ubuntu Health <${process.env.GMAIL_USER}>`,
+      to,
+      subject,
+      text,
+    })
+
+    console.log('Cancellation email sent:', info.messageId)
+    return { sent: true, id: info.messageId }
+  } catch (err) {
+    console.error('Failed to send cancellation email:', err)
+    return { sent: false, reason: 'exception', error: err }
+  }
+}
+
+function buildAppointmentRescheduleEmail({ patientName, clinicName, newDate, newTime, oldDate, oldTime }) {
+  const displayName = patientName || 'Patient'
+  const displayClinic = clinicName || 'the clinic'
+  const displayNewDate = newDate || 'Unknown date'
+  const displayNewTime = newTime || 'Unknown time'
+  const displayOldDate = oldDate || 'Unknown date'
+  const displayOldTime = oldTime || 'Unknown time'
+
+  const subject = `Appointment Rescheduled — ${displayClinic}`
+
+  const text = `
+Hi ${displayName},
+
+Your appointment has been rescheduled.
+
+Clinic:       ${displayClinic}
+Previous:     ${displayOldDate} at ${displayOldTime}
+New date:     ${displayNewDate}
+New time:     ${displayNewTime}
+
+Please arrive a few minutes early. If you need to make further changes, please contact the clinic directly.
+
+Ubuntu Health
+  `.trim()
+
+  return { subject, text }
+}
+
+async function sendAppointmentRescheduleEmail({ to, patientName, clinicName, newDate, newTime, oldDate, oldTime }) {
+  if (!to) {
+    console.warn('sendAppointmentRescheduleEmail: no recipient email, skipping')
+    return { sent: false, reason: 'no_email' }
+  }
+
+  const transporter = getTransporter()
+  if (!transporter) {
+    console.warn('sendAppointmentRescheduleEmail: GMAIL_USER or GMAIL_APP_PASSWORD not set, skipping')
+    return { sent: false, reason: 'no_credentials' }
+  }
+
+  const { subject, text } = buildAppointmentRescheduleEmail({
+    patientName,
+    clinicName,
+    newDate,
+    newTime,
+    oldDate,
+    oldTime,
+  })
+
+  try {
+    const info = await transporter.sendMail({
+      from: `Ubuntu Health <${process.env.GMAIL_USER}>`,
+      to,
+      subject,
+      text,
+    })
+
+    console.log('Reschedule email sent:', info.messageId)
+    return { sent: true, id: info.messageId }
+  } catch (err) {
+    console.error('Failed to send reschedule email:', err)
+    return { sent: false, reason: 'exception', error: err }
+  }
+}
+
 module.exports = {
   buildAppointmentConfirmationEmail,
   sendAppointmentConfirmationEmail,
+  buildAppointmentCancellationEmail,
+  sendAppointmentCancellationEmail,
+  buildAppointmentRescheduleEmail,
+  sendAppointmentRescheduleEmail,
 }


### PR DESCRIPTION
- Add buildAppointmentCancellationEmail and sendAppointmentCancellationEmail to emailService.js
- Add buildAppointmentRescheduleEmail and sendAppointmentRescheduleEmail to emailService.js
- Wire cancellation email into PATCH /api/appointments/:id/cancel
- Wire reschedule email into PATCH /api/appointments/:id/reschedule
- Both emails are fire-and-forget, failures do not affect appointment response
- Closes #689, #690, #691, #692, #694, #695, #696, #697